### PR TITLE
sigma -> sigma^2

### DIFF
--- a/lab/10_regularyzacja.ipynb
+++ b/lab/10_regularyzacja.ipynb
@@ -243,7 +243,7 @@
     "Dodatkowo potrzebujemy:\n",
     "\n",
     "<font size=\"+2\"> $$ \\overline{\\mu}_{t+1} =  (1 - \\lambda) \\overline{\\mu}_{t} + \\lambda \\mu_B $$ </font>\n",
-    "<font size=\"+2\"> $$ \\overline{\\sigma}_{t+1} =  (1 - \\lambda) \\overline{\\sigma}_{t} + \\lambda \\sigma_B $$ </font>\n",
+    "<font size=\"+2\"> $$ \\overline{\\sigma^2}_{t+1} =  (1 - \\lambda) \\overline{\\sigma^2}_{t} + \\lambda \\sigma^2_B $$ </font>\n",
     "\n",
     "**Pytania:**\n",
     "1. Jak działa BN w fazie treningu, a jak w fazie predykcji?\n",
@@ -393,7 +393,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Wydaje mi się, że wzór powinien sugerować trzymanie w pamięci średniej kroczącej wariancji, a nie odchylenia standardowego - przynajmniej taka implementacja przechodzi testy w checkerze.